### PR TITLE
Save-tiny-components, picker, and pos normalize;

### DIFF
--- a/src/entry/draw.rs
+++ b/src/entry/draw.rs
@@ -45,7 +45,7 @@ pub fn run_draw(args: &[String]) -> Result<(), Box<dyn std::error::Error>> {
   let g_pos: GraphPos = GraphPos::new(g, position, dim)?;
 
   let mut img = Img::new(config.width, config.width);
-  g_pos.draw_to_img(&mut img);
+  g_pos.draw_to_img(&mut img, true);
   img.save("data/output.png")?;
 
   Ok(())

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -3,6 +3,7 @@ use std::rc::{Rc, Weak};
 mod build;
 mod util;
 mod pos;
+mod coarsen;
 
 pub use pos::GraphPos;
 
@@ -59,82 +60,5 @@ impl Graph {
       panic!("Idx out of bounds...");
     }
     &self.adj[idx]
-  }
-
-  pub fn coarsen(&self) -> CoarsenLink {
-    let len: usize = self.len();
-    
-    let mut keep: Vec<usize> = vec![0; len];
-    let mut len1: usize = 0;
-    for idx in 0..len {
-      if keep[idx] == len {
-        continue;
-      }
-      
-      len1 += 1;
-      let nexts: &Vec<usize> = self.get_nexts(idx);
-      for next in nexts.iter() {
-        keep[*next] = len;
-      }
-    }
-
-    let mut visited: Vec<bool> = vec![false; len];
-    let mut mapping: Vec<usize> = Vec::with_capacity(len1);
-    let mut idx: usize = 0;
-    let mut adj_dis2: Vec<Vec<usize>> = Vec::with_capacity(len1);
-    let mut adj_dis3: Vec<Vec<usize>> = Vec::with_capacity(len1);
-    for idx1 in 0..len1 {
-      while idx < len && keep[idx] == len {
-        idx += 1;
-      }
-      mapping.push(idx);
-      keep[idx] = idx1;
-
-      visited[idx] = true;
-      let ns1: &Vec<usize> = self.get_nexts(idx);
-      util::set_vec_at_idxs_to(&mut visited, ns1, true);
-
-      let ns2: Vec<usize> = util::get_nexts_nexts(self, &mut visited, &ns1);
-      let ns3: Vec<usize> = util::get_nexts_nexts(self, &mut visited, &ns2);
-
-      util::set_vec_at_idxs_to(&mut visited, &ns3, false);
-      util::set_vec_at_idxs_to(&mut visited, &ns2, false);
-      util::set_vec_at_idxs_to(&mut visited, ns1, false);
-
-      visited[idx] = false;
-      adj_dis2.push(ns2);
-      adj_dis3.push(ns3);
-      idx += 1;
-    }
-    
-    let mut adj1: Vec<Vec<usize>> = Vec::with_capacity(len1);
-    for idx1 in 0..len1 {
-      let mut nexts1: Vec<usize> = Vec::new();
-      for next in adj_dis2[idx1].iter() {
-        if keep[*next] < len {
-          // print!("{} ", keep[*next]);
-          nexts1.push(keep[*next]);
-        }
-      }
-      adj1.push(nexts1); 
-    }
-
-    let (count, belong) = util::get_groups(&adj1);
-    if count > 0 {
-      for i1 in 0..len1 {
-        let ref mut nexts1 = adj1[i1];
-        
-        for j0 in adj_dis3[i1].iter() {
-          if keep[*j0] < len {
-            let j1 = keep[*j0];
-            // print!("{} ", keep[*next]);
-            if belong[j1] != belong[i1] {
-              nexts1.push(j1);
-            }
-          }
-        }
-      }
-    }
-    CoarsenLink { g0: Rc::clone(&self.me.upgrade().unwrap()), g1:Graph::from_adj(adj1), mapping}
   }
 }

--- a/src/graph/coarsen.rs
+++ b/src/graph/coarsen.rs
@@ -1,0 +1,98 @@
+use std::rc::Rc;
+
+mod picker;
+
+use super::{Graph, CoarsenLink};
+use super::util;
+
+impl Graph {
+  pub fn coarsen(&self) -> CoarsenLink {
+    let len: usize = self.len();
+    let lb: usize = 10;
+
+    let (sizes0, belong0) = util::get_groups(&self.adj);
+    let mut save: Vec<bool> = vec![false; len];
+    for (i, v) in save.iter_mut().enumerate() {
+      if sizes0[belong0[i]] < lb {
+        *v = true;
+      }
+    }
+
+    let (len1, mut keep) = picker::degree_sort_picker(&self.adj, &save);
+
+    let mut visited: Vec<bool> = vec![false; len];
+    let mut mapping: Vec<usize> = Vec::with_capacity(len1);
+    let mut idx: usize = 0;
+    let mut adj_dis2: Vec<Vec<usize>> = Vec::with_capacity(len1);
+    let mut adj_dis3: Vec<Vec<usize>> = Vec::with_capacity(len1);
+    for idx1 in 0..len1 {
+      while idx < len && keep[idx] == len {
+        idx += 1;
+      }
+      mapping.push(idx);
+      keep[idx] = idx1;
+
+      if !save[idx] {
+        visited[idx] = true;
+        let ns1: &Vec<usize> = self.get_nexts(idx);
+        util::set_vec_at_idxs_to(&mut visited, ns1, true);
+
+        let ns2: Vec<usize> = util::get_nexts_nexts(self, &mut visited, &ns1);
+        let ns3: Vec<usize> = util::get_nexts_nexts(self, &mut visited, &ns2);
+
+        util::set_vec_at_idxs_to(&mut visited, &ns3, false);
+        util::set_vec_at_idxs_to(&mut visited, &ns2, false);
+        util::set_vec_at_idxs_to(&mut visited, ns1, false);
+
+        visited[idx] = false;
+        adj_dis2.push(ns2);
+        adj_dis3.push(ns3);
+      } else {
+        adj_dis2.push(Vec::new());
+        adj_dis3.push(Vec::new());
+      }
+      idx += 1;
+    }
+    
+    let mut adj1: Vec<Vec<usize>> = Vec::with_capacity(len1);
+    for idx1 in 0..len1 {
+      let idx = mapping[idx1]; // Bug found here, mapping in the wrong direction
+      let mut nexts1: Vec<usize> = Vec::new();
+      if !save[idx] {
+        for next in adj_dis2[idx1].iter() {
+          if keep[*next] < len {
+            // print!("{} ", keep[*next]);
+            nexts1.push(keep[*next]);
+          }
+        }
+      } else {
+        for next in self.get_nexts(idx).iter() {
+          if keep[*next] < len {
+            // print!("{} ", keep[*next]);
+            nexts1.push(keep[*next]);
+          }
+        }
+      }
+      
+      adj1.push(nexts1); 
+    }
+
+    let (_, belong) = util::get_groups(&adj1);
+    // if sizes.len() > 0 {
+      for i1 in 0..len1 {
+        let ref mut nexts1 = adj1[i1];
+        
+        for j0 in adj_dis3[i1].iter() {
+          if keep[*j0] < len {
+            let j1 = keep[*j0];
+            // print!("{} ", keep[*next]);
+            if belong[j1] != belong[i1] {
+              nexts1.push(j1);
+            }
+          }
+        }
+      // }
+    }
+    CoarsenLink { g0: Rc::clone(&self.me.upgrade().unwrap()), g1:Graph::from_adj(adj1), mapping}
+  }
+}

--- a/src/graph/coarsen/picker.rs
+++ b/src/graph/coarsen/picker.rs
@@ -1,0 +1,50 @@
+pub fn sequential_picker(adj: &Vec<Vec<usize>>, save: &Vec<bool>) -> (usize, Vec<usize>) {
+  let len: usize = adj.len();
+  let mut keep: Vec<usize> = vec![0; len];
+  let mut len1: usize = 0;
+  for idx in 0..len {
+    if keep[idx] == len {
+      continue;
+    }
+    
+    len1 += 1;
+    if !save[idx] {
+      let nexts: &Vec<usize> = &adj[idx];
+      for next in nexts.iter() {
+        keep[*next] = len;
+      }
+    }
+  }
+  (len1, keep)
+}
+
+pub fn degree_sort_picker(adj: &Vec<Vec<usize>>, save: &Vec<bool>) -> (usize, Vec<usize>) {
+  let len: usize = adj.len();
+  let mut keep: Vec<usize> = vec![0; len];
+  let mut len1: usize = 0;
+  let mut degrees: Vec<(usize, usize)> = Vec::with_capacity(len);
+  for idx in 0..len {
+    if !save[idx] {
+      degrees.push((adj[idx].len(), idx));
+    } else {
+      len1 += 1;
+    }
+  }
+
+  degrees.sort();
+
+  for (_, idx) in degrees.iter() {
+    if keep[*idx] == len {
+      continue;
+    }
+    
+    len1 += 1;
+    if !save[*idx] {
+      let nexts: &Vec<usize> = &adj[*idx];
+      for next in nexts.iter() {
+        keep[*next] = len;
+      }
+    }
+  }
+  (len1, keep)
+}

--- a/src/graph/pos/normalizer.rs
+++ b/src/graph/pos/normalizer.rs
@@ -1,0 +1,76 @@
+pub fn normalize2d_center(pos: &Vec<f32>, dim: usize) -> Vec<f32> {
+  let size: usize = pos.len() / dim;
+  let d2: usize = 2;
+  let mut res: Vec<f32> = Vec::with_capacity(size * d2);
+  for i in 0..size {
+    res.push(pos[i * dim + 0]);
+    res.push(pos[i * dim + 1]);
+  }
+
+  let mut x: f32 = 0.0;
+  let mut y: f32 = 0.0;
+
+  for i in 0..size {
+    x += res[i * d2];
+    y += res[i * d2 + 1];
+  }
+
+  x /= size as f32;
+  y /= size as f32;
+
+  for i in 0..size {
+    res[i * d2] -= x;
+    res[i * d2 + 1] -= y;
+  }
+  let mut max_r: f32 = 0.0;
+  for i in 0..size {
+    let curr = res[i * d2].powi(2) + res[i * d2 + 1].powi(2);
+    max_r = max_r.max(curr);
+  }
+
+  max_r = max_r.sqrt() * 1.1;
+
+  for v in res.iter_mut() {
+    *v /= max_r;
+    *v /= 2.0;
+    *v += 0.5;
+  }
+
+  res
+}
+
+pub fn normalize2d_full(pos: &Vec<f32>, dim: usize) -> Vec<f32> {
+  let size: usize = pos.len() / dim;
+  let d2: usize = 2;
+  let mut res: Vec<f32> = Vec::with_capacity(size * d2);
+  for i in 0..size {
+    res.push(pos[i * dim + 0]);
+    res.push(pos[i * dim + 1]);
+  }
+
+  let mut x_min: f32 = res[0];
+  let mut x_max: f32 = res[0];
+  let mut y_min: f32 = res[1];
+  let mut y_max: f32 = res[1];
+
+  for i in 0..size {
+    x_min = x_min.min(res[i * d2]);
+    x_max = x_max.max(res[i * d2]);
+    y_min = y_min.min(res[i * d2 + 1]);
+    y_max = y_max.max(res[i * d2 + 1]);
+  }
+
+  let x_range = x_max - x_min;
+  let y_range = y_max - y_min;
+  let mut range = x_range.max(y_range);
+  if range == 0.0 {
+    range = 1.0;
+  }
+
+  for i in 0..size {
+    res[i * d2] = 0.5 + (res[i * d2] - x_min - (x_range / 2.0)) / range;
+    res[i * d2 + 1] = 0.5 + (res[i * d2 + 1] - y_min - (y_range / 2.0)) / range;
+  }
+
+  res
+}

--- a/src/graph/util.rs
+++ b/src/graph/util.rs
@@ -21,7 +21,7 @@ pub fn get_nexts_nexts(g: &Graph, v: &mut Vec<bool>, ns: &Vec<usize>) -> Vec<usi
   ans
 }
 
-pub fn get_groups(adj: &Vec<Vec<usize>>) ->(usize, Vec<usize>) {
+pub fn get_groups(adj: &Vec<Vec<usize>>) ->(Vec<usize>, Vec<usize>) {
   let len: usize = adj.len();
   let mut v: Vec<bool> = vec![false; len];
   let mut res: Vec<usize> = Vec::with_capacity(len);
@@ -50,12 +50,17 @@ pub fn get_groups(adj: &Vec<Vec<usize>>) ->(usize, Vec<usize>) {
     }
     let mut q: VecDeque<usize> = VecDeque::new();
     q.push_back(i);
+    res[i] = count; // Bug here, forgot to set the first one
     v[i] = true;
     while !q.is_empty() {
       iter_bfs_nexts(&adj, &mut q, &mut v, &mut res, count);
     }
     count += 1;
   }
+  let mut sizes: Vec<usize> = vec![0; count];
+  for belong in res.iter() {
+    sizes[*belong] += 1;
+  }
 
-  (count, res)
+  (sizes, res)
 }

--- a/src/img.rs
+++ b/src/img.rs
@@ -55,8 +55,8 @@ impl Img {
       }
       let offset = self.get_index(row, col);
       // for d in 0..4 {
-      self.data[(offset * 4 + 0) as usize] = 204;
-      self.data[(offset * 4 + 1) as usize] = 0;
+      self.data[(offset * 4 + 0) as usize] = 255;
+      self.data[(offset * 4 + 1) as usize] = 255;
       self.data[(offset * 4 + 2) as usize] = 255;
       self.data[(offset * 4 + 3) as usize] = 255;
       // }
@@ -82,8 +82,8 @@ impl Img {
       let w = self.w as f32;
       let h = self.h as f32;
       self.draw_line((r0 * w) as usize,
-       (c0 * h) as usize,
-        (r1 * w) as usize,
-         (c1 * h) as usize);
+      (c0 * h) as usize,
+      (r1 * w) as usize,
+      (c1 * h) as usize);
     }
 }


### PR DESCRIPTION
## Save tiny components

During the coarsening process, different sizes of components may lead to different levels of coarsening. This might potentially lead to a dangling one-node component, which will be ignored and cause errors during the edge construction process.

In order to prevent small components from quickly disappearing, I added the "save" logic inside the coarsening function. The nodes belonging to a small component will not be further coarsened, and their connections will remain the same instead of getting additional new edges of length "2" or "3".

## Picker

In general, I would say the Maximum Independent Vertex Set coarsening algorithm consists of two parts: vertex picking and linking picked vertices. I will try to refactor the existing coarsen algorithm into smaller modules while trying to be performant, like not recalculating the "BFS of 2" during the linking process.

## Pos normalization

How to map those positions of vertices into a 2D plane is a problem. I currently have two ways of putting positions into the range of 0-1 for pixel mappings: calculating the center of the vertices and shrinking them with the radius of the group or calculating the range of the first two dimensions, fitting them into the box with the maximum range to preserve the aspect ratio.